### PR TITLE
feat: add password visibility toggle with SVG icons

### DIFF
--- a/src/pages/auth/components/ConfirmPasswordInput.tsx
+++ b/src/pages/auth/components/ConfirmPasswordInput.tsx
@@ -1,9 +1,11 @@
+import { useState } from "react";
 import type { FieldErrors, UseFormRegister } from "react-hook-form";
 import {
   ErrorMessage,
   InputWrapper,
   StyledInput,
 } from "@auth/styles/inputFieldStyle";
+import styled from "styled-components";
 
 interface ConfirmPasswordInputProps {
   register: UseFormRegister<any>;
@@ -16,16 +18,64 @@ export default function ConfirmPasswordInput({
   errors,
   password,
 }: ConfirmPasswordInputProps) {
+  const [showPassword, setShowPassword] = useState(false);
+
   return (
     <InputWrapper>
-      <StyledInput
-        {...register("confirmPassword", {
-          required: "Fill in the confirm password field",
-          validate: (value) => value === password || "Password do not match.",
-        })}
-        placeholder="Password confirm"
-        type="password"
-      />
+      <PasswordInputContainer>
+        <StyledInput
+          {...register("confirmPassword", {
+            required: "Fill in the confirm password field",
+            validate: (value) => value === password || "Password do not match.",
+          })}
+          placeholder="Password confirm"
+          type={showPassword ? "text" : "password"}
+        />
+        <ToggleButton
+          type="button"
+          onClick={() => setShowPassword(!showPassword)}
+          aria-label={showPassword ? "Hide password" : "Show password"}
+        >
+          {showPassword ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              width="20"
+              height="20"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"
+              />
+            </svg>
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              width="20"
+              height="20"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              />
+            </svg>
+          )}
+        </ToggleButton>
+      </PasswordInputContainer>
       {errors.confirmPassword && (
         <ErrorMessage style={{ color: "red" }}>
           {errors.confirmPassword.message?.toString()}
@@ -34,3 +84,33 @@ export default function ConfirmPasswordInput({
     </InputWrapper>
   );
 }
+
+const PasswordInputContainer = styled.div`
+  position: relative;
+  width: 100%;
+  display: flex;
+  align-items: center;
+`;
+
+const ToggleButton = styled.button`
+  position: absolute;
+  right: 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.6;
+  transition: opacity 0.2s ease;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &:focus {
+    outline: none;
+    opacity: 1;
+  }
+`;

--- a/src/pages/auth/components/PasswordInput.tsx
+++ b/src/pages/auth/components/PasswordInput.tsx
@@ -1,9 +1,11 @@
+import { useState } from "react";
 import type { FieldErrors, UseFormRegister } from "react-hook-form";
 import {
   ErrorMessage,
   InputWrapper,
   StyledInput,
 } from "@auth/styles/inputFieldStyle";
+import styled from "styled-components";
 
 interface PasswordInputProps {
   register: UseFormRegister<any>;
@@ -14,19 +16,67 @@ export default function PasswordInput({
   register,
   errors,
 }: PasswordInputProps) {
+  const [showPassword, setShowPassword] = useState(false);
+
   return (
     <InputWrapper>
-      <StyledInput
-        {...register("password", {
-          required: "Put your password",
-          minLength: {
-            value: 6,
-            message: "Password must be longer than 6 characters",
-          },
-        })}
-        placeholder="Password"
-        type="password"
-      />
+      <PasswordInputContainer>
+        <StyledInput
+          {...register("password", {
+            required: "Put your password",
+            minLength: {
+              value: 6,
+              message: "Password must be longer than 6 characters",
+            },
+          })}
+          placeholder="Password"
+          type={showPassword ? "text" : "password"}
+        />
+        <ToggleButton
+          type="button"
+          onClick={() => setShowPassword(!showPassword)}
+          aria-label={showPassword ? "Hide password" : "Show password"}
+        >
+          {showPassword ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              width="20"
+              height="20"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"
+              />
+            </svg>
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              width="20"
+              height="20"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              />
+            </svg>
+          )}
+        </ToggleButton>
+      </PasswordInputContainer>
       {errors.password && (
         <ErrorMessage style={{ color: "red" }}>
           {errors.password.message?.toString()}
@@ -35,3 +85,34 @@ export default function PasswordInput({
     </InputWrapper>
   );
 }
+
+const PasswordInputContainer = styled.div`
+  position: relative;
+  width: 100%;
+  display: flex;
+  align-items: center;
+`;
+
+const ToggleButton = styled.button`
+  position: absolute;
+  right: 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  opacity: 0.6;
+  transition: opacity 0.2s ease;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &:focus {
+    outline: none;
+    opacity: 1;
+  }
+`;


### PR DESCRIPTION
**Summary**
- Add password visibility toggle to login and register password input fields
- Use SVG eye icons (open/slash) instead of emoji for better visual consistency
- Toggle button positioned inside input field with absolute positioning

**LOG IN PAGE**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b43b7556-39fb-4c34-8070-7fabea16791e" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0fa40de7-cc3f-4255-b69b-847c0359d790" />
**REGISTRATION PAGE**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3353c8cd-ac87-4e7d-af91-795ece205f4b" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dac72681-4566-45dd-9519-0ea439d330fd" />

 **Changes**

- **PasswordInput.tsx**: Added toggle button with eye icon SVG to show/hide password  on login page
- **ConfirmPasswordInput.tsx**: Added same toggle functionality for password confirmation field on register page

 **Implementation Details**
- Toggle state managed with React `useState` hook
- SVG icons from Heroicons with smooth opacity transitions
- Accessible with proper `aria-label` attributes
- Button positioned absolutely at right side of input field