### PR TITLE
feat: Add conditional navigation to Get Started button

### DIFF
--- a/src/pages/main/components/HeroSection.tsx
+++ b/src/pages/main/components/HeroSection.tsx
@@ -3,13 +3,22 @@ import a from "../assets/Long2ShortTextHorizontal.png";
 import { useNavigate } from "react-router-dom";
 import routePath from "@router/routePath";
 import { useTranslation } from "react-i18next";
+import { useContext } from "react";
+import { AuthContext } from "src/contexts/AuthContext";
 
 export default function HeroSection() {
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const { user } = useContext(AuthContext);
 
   const handleGetStarted = () => {
-    navigate(routePath.REGISTER);
+    if (user) {
+      // 로그인된 상태: Dashboard로 이동
+      navigate(routePath.DASHBOARD);
+    } else {
+      // 로그아웃 상태: Registration 페이지로 이동
+      navigate(routePath.REGISTER);
+    }
   };
 
   return (


### PR DESCRIPTION
- Logged-in users are redirected to dashboard
- Logged-out users are redirected to registration page
- Use AuthContext to check user login status

**변경파일**
src/pages/main/components/HeroSection.tsx

변경 내용:

1. 추가된 import (6-7번 줄):
useContext from "react"
AuthContext from "src/contexts/AuthContext"
2.추가된 코드 (12번 줄):
const { user } = useContext(AuthContext);
3.수정된 함수 (14-22번 줄):
handleGetStarted 함수 로직 변경

TEST PLAN


- [ ] user가 있으면 → /dashboard로 이동 (로그인 상태)

- [ ] user가 없으면 → /register로 이동 (로그아웃 상태)