### PR TITLE
fix the layout shift

### DIFF
--- a/src/components/SubtitleStyleSelector.tsx
+++ b/src/components/SubtitleStyleSelector.tsx
@@ -127,6 +127,7 @@ const CasualPreviewContainer = styled.div`
   align-items: center;
   justify-content: center;
   width: 100%;
+  min-height: 40px;
 `;
 
 const CasualWord = styled.span`
@@ -137,13 +138,14 @@ const CasualWord = styled.span`
   display: inline-block;
   font-family: 'Noto Sans CJK KR', sans-serif;
   color: white;
-  -webkit-text-stroke: 3.4px #000;
+  -webkit-text-stroke: 2.0px #000;
   paint-order: stroke fill;
   transition: all 0.3s ease;
+  will-change: transform;
 
   &.animate-active {
     color: #FFFF00 !important;
-    font-size: 23px;
+    transform: scale(1.28);
   }
 `;
 
@@ -155,6 +157,7 @@ const DynamicPreviewContainer = styled.div`
   align-items: center;
   justify-content: center;
   width: 100%;
+  min-height: 40px;
 `;
 
 const DynamicWord = styled.span`
@@ -166,12 +169,13 @@ const DynamicWord = styled.span`
   font-family: 'Noto Sans KR', sans-serif;
   color: white;
   text-transform: uppercase;
-  -webkit-text-stroke: 3.4px #000;
+  -webkit-text-stroke: 2.0px #000;
   paint-order: stroke fill;
   transition: all 0.3s ease;
+  will-change: transform;
 
   &.animate-active {
     color: #39ff14 !important;
-    font-size: 23px;
+    transform: scale(1.28);
   }
 `;


### PR DESCRIPTION

https://github.com/user-attachments/assets/9f43cbaa-325b-4ffa-97c6-652c34e8a19b

**1.font-size → transform: scale(1.28)로 변경**
transform은 레이아웃에 영향을 주지 않음 (GPU 가속)
scale 값 1.28은 18px → 23px와 동일한 비율 (23/18 = 1.28)
**2.min-height: 40px 추가**
컨테이너에 최소 높이를 설정하여 공간 확보
애니메이션이 컨테이너 밖으로 튀어나가지 않음
**3.will-change: transform 추가**
브라우저에게 변화를 미리 알림
애니메이션 성능 최적화

**4.바뀐 애니메이션,폰트 테두리 크기 재조정**